### PR TITLE
Feature/firebase auth

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -10,7 +10,7 @@ type:
 	docker-compose run --rm pipenv run mypy .
 
 test:
-	docker-compose run --rm pipenv run pytest -vvv -s
+	docker-compose run --rm pipenv run pytest ./firebase_auth/ -vvv -s
 
 
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -10,7 +10,7 @@ type:
 	docker-compose run --rm pipenv run mypy .
 
 test:
-	docker-compose run --rm pipenv run pytest ./firebase_auth/ -vvv -s
+	docker-compose run --rm pipenv run pytest -vvv -s
 
 
 

--- a/server/api_project/Pipfile
+++ b/server/api_project/Pipfile
@@ -8,6 +8,7 @@ Django = "*"
 psycopg2 = "*"
 djangorestframework = "*"
 uWSGI = "*"
+firebase-admin = "*"
 
 [dev-packages]
 unify = "*"
@@ -24,4 +25,3 @@ django-stubs = "*"
 
 [requires]
 python_version = "3.8"
-

--- a/server/api_project/Pipfile
+++ b/server/api_project/Pipfile
@@ -22,6 +22,7 @@ mypy = "*"
 pytest-mypy = "*"
 pytest-django = "*"
 django-stubs = "*"
+mock = "*"
 
 [requires]
 python_version = "3.8"

--- a/server/api_project/Pipfile.lock
+++ b/server/api_project/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2bf878d828d8928a2705d319fe30563c654494816283333159fa77acd25914d8"
+            "sha256": "839f25e52d20ab7887de3d7d42c7edae5f84308ab9748faf711bc178f5c825fd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -547,6 +547,14 @@
             ],
             "version": "==0.6.1"
         },
+        "mock": {
+            "hashes": [
+                "sha256:3f9b2c0196c60d21838f307f5825a7b86b678cedc58ab9e50a8988187b4d81e0",
+                "sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72"
+            ],
+            "index": "pypi",
+            "version": "==4.0.2"
+        },
         "mypy": {
             "hashes": [
                 "sha256:0a0d102247c16ce93c97066443d11e2d36e6cc2a32d8ccc1f705268970479324",
@@ -565,6 +573,7 @@
                 "sha256:eea260feb1830a627fb526d22fbb426b750d9f5a47b624e8d5e7e004359b219c"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8' and python_version < '3.9'",
             "version": "==0.790"
         },
         "mypy-extensions": {

--- a/server/api_project/Pipfile.lock
+++ b/server/api_project/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d7becc0cccb61abba39dc2359f6ecea426b4343649c88480d61e661ba04ef827"
+            "sha256": "2bf878d828d8928a2705d319fe30563c654494816283333159fa77acd25914d8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,79 @@
     "default": {
         "asgiref": {
             "hashes": [
-                "sha256:a5098bc870b80e7b872bff60bb363c7f2c2c89078759f6c47b53ff8c525a152e",
-                "sha256:cd88907ecaec59d78e4ac00ea665b03e571cb37e3a0e37b3702af1a9e86c365a"
+                "sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17",
+                "sha256:7162a3cb30ab0609f1a4c95938fd73e8604f63bdba516a7f7d64b83ff09478f0"
             ],
-            "version": "==3.3.0"
+            "version": "==3.3.1"
+        },
+        "cachecontrol": {
+            "hashes": [
+                "sha256:10d056fa27f8563a271b345207402a6dcce8efab7e5b377e270329c62471b10d",
+                "sha256:be9aa45477a134aee56c8fac518627e1154df063e85f67d4f83ce0ccc23688e8"
+            ],
+            "version": "==0.12.6"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:513d4ff98dd27f85743a8dc0e92f55ddb1b49e060c2d5961512855cda2c01a98",
+                "sha256:bbaa39c3dede00175df2dc2b03d0cf18dd2d32a7de7beb68072d13043c9edb20"
+            ],
+            "version": "==4.1.1"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd",
+                "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
+            ],
+            "version": "==2020.11.8"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:005f2bfe11b6745d726dbb07ace4d53f057de66e336ff92d61b8c7e9c8f4777d",
+                "sha256:09e96138280241bd355cd585148dec04dbbedb4f46128f340d696eaafc82dd7b",
+                "sha256:0b1ad452cc824665ddc682400b62c9e4f5b64736a2ba99110712fdee5f2505c4",
+                "sha256:0ef488305fdce2580c8b2708f22d7785ae222d9825d3094ab073e22e93dfe51f",
+                "sha256:15f351bed09897fbda218e4db5a3d5c06328862f6198d4fb385f3e14e19decb3",
+                "sha256:22399ff4870fb4c7ef19fff6eeb20a8bbf15571913c181c78cb361024d574579",
+                "sha256:23e5d2040367322824605bc29ae8ee9175200b92cb5483ac7d466927a9b3d537",
+                "sha256:2791f68edc5749024b4722500e86303a10d342527e1e3bcac47f35fbd25b764e",
+                "sha256:2f9674623ca39c9ebe38afa3da402e9326c245f0f5ceff0623dccdac15023e05",
+                "sha256:3363e77a6176afb8823b6e06db78c46dbc4c7813b00a41300a4873b6ba63b171",
+                "sha256:33c6cdc071ba5cd6d96769c8969a0531be2d08c2628a0143a10a7dcffa9719ca",
+                "sha256:3b8eaf915ddc0709779889c472e553f0d3e8b7bdf62dab764c8921b09bf94522",
+                "sha256:3cb3e1b9ec43256c4e0f8d2837267a70b0e1ca8c4f456685508ae6106b1f504c",
+                "sha256:3eeeb0405fd145e714f7633a5173318bd88d8bbfc3dd0a5751f8c4f70ae629bc",
+                "sha256:44f60519595eaca110f248e5017363d751b12782a6f2bd6a7041cba275215f5d",
+                "sha256:4d7c26bfc1ea9f92084a1d75e11999e97b62d63128bcc90c3624d07813c52808",
+                "sha256:529c4ed2e10437c205f38f3691a68be66c39197d01062618c55f74294a4a4828",
+                "sha256:6642f15ad963b5092d65aed022d033c77763515fdc07095208f15d3563003869",
+                "sha256:85ba797e1de5b48aa5a8427b6ba62cf69607c18c5d4eb747604b7302f1ec382d",
+                "sha256:8f0f1e499e4000c4c347a124fa6a27d37608ced4fe9f7d45070563b7c4c370c9",
+                "sha256:a624fae282e81ad2e4871bdb767e2c914d0539708c0f078b5b355258293c98b0",
+                "sha256:b0358e6fefc74a16f745afa366acc89f979040e0cbc4eec55ab26ad1f6a9bfbc",
+                "sha256:bbd2f4dfee1079f76943767fce837ade3087b578aeb9f69aec7857d5bf25db15",
+                "sha256:bf39a9e19ce7298f1bd6a9758fa99707e9e5b1ebe5e90f2c3913a47bc548747c",
+                "sha256:c11579638288e53fc94ad60022ff1b67865363e730ee41ad5e6f0a17188b327a",
+                "sha256:c150eaa3dadbb2b5339675b88d4573c1be3cb6f2c33a6c83387e10cc0bf05bd3",
+                "sha256:c53af463f4a40de78c58b8b2710ade243c81cbca641e34debf3396a9640d6ec1",
+                "sha256:cb763ceceae04803adcc4e2d80d611ef201c73da32d8f2722e9d0ab0c7f10768",
+                "sha256:cc75f58cdaf043fe6a7a6c04b3b5a0e694c6a9e24050967747251fb80d7bce0d",
+                "sha256:d80998ed59176e8cba74028762fbd9b9153b9afc71ea118e63bbf5d4d0f9552b",
+                "sha256:de31b5164d44ef4943db155b3e8e17929707cac1e5bd2f363e67a56e3af4af6e",
+                "sha256:e66399cf0fc07de4dce4f588fc25bfe84a6d1285cc544e67987d22663393926d",
+                "sha256:f0620511387790860b249b9241c2f13c3a80e21a73e0b861a2df24e9d6f56730",
+                "sha256:f4eae045e6ab2bb54ca279733fe4eb85f1effda392666308250714e01907f394",
+                "sha256:f92cdecb618e5fa4658aeb97d5eb3d2f47aa94ac6477c6daf0f306c5a3b9e6b1",
+                "sha256:f92f789e4f9241cd262ad7a555ca2c648a98178a953af117ef7fad46aa1d5591"
+            ],
+            "version": "==1.14.3"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
         },
         "django": {
             "hashes": [
@@ -37,6 +106,219 @@
             ],
             "index": "pypi",
             "version": "==3.12.2"
+        },
+        "firebase-admin": {
+            "hashes": [
+                "sha256:44bb982951cfa201a99a59657a58f66eb367c362fe90200d0816f39df9862ff3",
+                "sha256:7004336c1fdb31a3f33e862d372ef5a349444a4b1a32e400d9d9b898cce463ae"
+            ],
+            "index": "pypi",
+            "version": "==4.4.0"
+        },
+        "google-api-core": {
+            "hashes": [
+                "sha256:1bb3c485c38eacded8d685b1759968f6cf47dd9432922d34edb90359eaa391e2",
+                "sha256:94d8c707d358d8d9e8b0045c42be20efb58433d308bd92cf748511c7825569c8"
+            ],
+            "version": "==1.23.0"
+        },
+        "google-api-python-client": {
+            "hashes": [
+                "sha256:1892cd490d164e5ec2f2168dc3b4fa0af68f36ca15a88b91bca1826b3d4f2829",
+                "sha256:203d5453660867136aae61922c5d849163fb9be478985fad84e09dee6f605c06"
+            ],
+            "version": "==1.12.5"
+        },
+        "google-auth": {
+            "hashes": [
+                "sha256:5176db85f1e7e837a646cd9cede72c3c404ccf2e3373d9ee14b2db88febad440",
+                "sha256:b728625ff5dfce8f9e56a499c8a4eb51443a67f20f6d28b67d5774c310ec4b6b"
+            ],
+            "version": "==1.23.0"
+        },
+        "google-auth-httplib2": {
+            "hashes": [
+                "sha256:8d092cc60fb16517b12057ec0bba9185a96e3b7169d86ae12eae98e645b7bc39",
+                "sha256:aeaff501738b289717fac1980db9711d77908a6c227f60e4aa1923410b43e2ee"
+            ],
+            "version": "==0.0.4"
+        },
+        "google-cloud-core": {
+            "hashes": [
+                "sha256:21afb70c1b0bce8eeb8abb5dca63c5fd37fc8aea18f4b6d60e803bd3d27e6b80",
+                "sha256:75abff9056977809937127418323faa3917f32df68490704d39a4f0d492ebc2b"
+            ],
+            "version": "==1.4.3"
+        },
+        "google-cloud-firestore": {
+            "hashes": [
+                "sha256:ae1f58d9174a6fb2c9fd2758c6d4fd237fb4f0decc632b80c217bfbceda38eb6",
+                "sha256:e8a832658cf44d529a00f63da61be11eedf0988222d06e1c74d73b4ee8533687"
+            ],
+            "markers": "platform_python_implementation != 'PyPy'",
+            "version": "==2.0.1"
+        },
+        "google-cloud-storage": {
+            "hashes": [
+                "sha256:063bd12b5ceb4045e8681dc5cce8c3ceeb1203f7c5c3e59f5c9b75bb79a5f59b",
+                "sha256:da12b7bd79bbe978a7945a44b600604fbc10ece2935d31f243e751f99135e34f"
+            ],
+            "version": "==1.32.0"
+        },
+        "google-crc32c": {
+            "hashes": [
+                "sha256:00b34d4c9ac565b2be553f81f58e5861e51d43af2043ed7cbfe1853ee2f54671",
+                "sha256:17223ac9135eab28e874ff1e221810190d109a1abd482451d0776dc388be14de",
+                "sha256:176cef33c9ad2a56977efd084646b378e50ab14b43a7c0a16e956bc3e3ec130a",
+                "sha256:1a613f43534c9a345cc86fc6531bda477e2473cb876b6e26aee22b8060917069",
+                "sha256:337566ce49d7ea7493f95bd6bc89ab08640caa91b6105cea0be57ed026980e74",
+                "sha256:41fb6c22cd72ae3db4d98d28dbb768d53397c8fc3cb8ab945fd434e842e622d4",
+                "sha256:438d6c314a52d50a9523460024e655a3d27774adde47d72eebccc89dc9eec992",
+                "sha256:6fd5d861421c37786b9c1a87dc7b0d8349a426151a461d5724b76c5a07f6ae9b",
+                "sha256:7b5ccdc7697ca54351d2965d4241f907d53f26f5288710bed505f8c3776ed235",
+                "sha256:7f44c5259f6b2f8b2b6f668dbaa954693a10e97811345c193e46b933c2dd5165",
+                "sha256:9439b960b6ecd847557675d130fc3626d762bf535da595c20a6949a705fb3eae",
+                "sha256:b6fad0842a02abd270f8b660db082d37d197ab80aa4db6a2ddbfcf472eade9e7",
+                "sha256:b7ee33659231c8205bb05559781ac61a325f31b06b917b3e997bea5c2c49ff4d",
+                "sha256:cda3a6829e8b5bf6058615e53387430d004590c9b0ad808e53fea5bec35bbe44",
+                "sha256:cf373207380e54c42da6c88baf1f7a31c2d9f29b87c9c922d5147d219eed55aa",
+                "sha256:ec4d91c9236b0576d9d2b23c7eb85c6a6372b88afe2d0c64681cf11629586f74",
+                "sha256:f3b859200c3bc73925b1719ed8b1f6d8d73b6620b42dbc121c4df58423045e34",
+                "sha256:f54c90058e3f56e55fa0f699c6f4ceaaa825ea7f17ef2adbf07b2b06b27455e7"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
+        },
+        "google-resumable-media": {
+            "hashes": [
+                "sha256:dcdab13e95bc534d268f87d5293e482cce5bc86dfce6ca0f2e2e89cbb73ef38c",
+                "sha256:ecabcd90d74a6e00331af0c87f500f238c44870d9626e01b385dda3af7b99269"
+            ],
+            "version": "==1.1.0"
+        },
+        "googleapis-common-protos": {
+            "hashes": [
+                "sha256:560716c807117394da12cecb0a54da5a451b5cf9866f1d37e9a5e2329a665351",
+                "sha256:c8961760f5aad9a711d37b675be103e0cc4e9a39327e0d6d857872f698403e24"
+            ],
+            "version": "==1.52.0"
+        },
+        "grpcio": {
+            "hashes": [
+                "sha256:02a4a637a774382d6ac8e65c0a7af4f7f4b9704c980a0a9f4f7bbc1e97c5b733",
+                "sha256:08b6a58c8a83e71af5650f8f879fe14b7b84dce0c4969f3817b42c72989dacf0",
+                "sha256:0aeed3558a0eec0b31700af6072f1c90e8fd5701427849e76bc469554a14b4f5",
+                "sha256:0cebba3907441d5c620f7b491a780ed155140fbd590da0886ecfb1df6ad947b9",
+                "sha256:143b4fe72c01000fc0667bf62ace402a6518939b3511b3c2bec04d44b1d7591c",
+                "sha256:21265511880056d19ce4f809ce3fbe2a3fa98ec1fc7167dbdf30a80d3276202e",
+                "sha256:289671cfe441069f617bf23c41b1fa07053a31ff64de918d1016ac73adda2f73",
+                "sha256:2d5124284f9d29e4f06f674a12ebeb23fc16ce0f96f78a80a6036930642ae5ab",
+                "sha256:2f2eabfd514af8945ee415083a0f849eea6cb3af444999453bb6666fadc10f54",
+                "sha256:3ac453387add933b6cfbc67cc8635f91ff9895299130fc612c3c4b904e91d82a",
+                "sha256:407b4d869ce5c6a20af5b96bb885e3ecaf383e3fb008375919eb26cf8f10d9cd",
+                "sha256:4bb771c4c2411196b778871b519c7e12e87f3fa72b0517b22f952c64ead07958",
+                "sha256:4cef3eb2df338abd9b6164427ede961d351c6bf39b4a01448a65f9e795f56575",
+                "sha256:514b4a6790d6597fc95608f49f2f13fe38329b2058538095f0502b734b98ffd2",
+                "sha256:52143467237bfa77331ed1979dc3e203a1c12511ee37b3ddd9ff41b05804fb10",
+                "sha256:56e2a985efdba8e2282e856470b684e83a3cadd920f04fcd360b4b826ced0dd3",
+                "sha256:592656b10528aa327058d2007f7ab175dc9eb3754b289e24cac36e09129a2f6b",
+                "sha256:5b21d3de520a699cb631cfd3a773a57debeb36b131be366bf832153405cc5404",
+                "sha256:62ce7e86f11e8c4ff772e63c282fb5a7904274258be0034adf37aa679cf96ba0",
+                "sha256:65b06fa2db2edd1b779f9b256e270f7a58d60e40121660d8b5fd6e8b88f122ed",
+                "sha256:6a1b5b7e47600edcaeaa42983b1c19e7a5892c6b98bcde32ae2aa509a99e0436",
+                "sha256:703da25278ee7318acb766be1c6d3b67d392920d002b2d0304e7f3431b74f6c1",
+                "sha256:7744468ee48be3265db798f27e66e118c324d7831a34fd39d5775bcd5a70a2c4",
+                "sha256:7c1ea6ea6daa82031af6eb5b7d1ab56b1193840389ea7cf46d80e98636f8aff5",
+                "sha256:7d292dabf7ded9c062357f8207e20e94095a397d487ffd25aa213a2c3dff0ab4",
+                "sha256:7f727b8b6d9f92fcab19dbc62ec956d8352c6767b97b8ab18754b2dfa84d784f",
+                "sha256:7fda62846ef8d86caf06bd1ecfddcae2c7e59479a4ee28808120e170064d36cc",
+                "sha256:85e56ab125b35b1373205b3802f58119e70ffedfe0d7e2821999126058f7c44f",
+                "sha256:88f2a102cbc67e91f42b4323cec13348bf6255b25f80426088079872bd4f3c5c",
+                "sha256:89add4f4cda9546f61cb8a6988bc5b22101dd8ca4af610dff6f28105d1f78695",
+                "sha256:8cf67b8493bff50fa12b4bc30ab40ce1f1f216eb54145962b525852959b0ab3d",
+                "sha256:a8c84db387907e8d800c383e4c92f39996343adedf635ae5206a684f94df8311",
+                "sha256:abaf30d18874310d4439a23a0afb6e4b5709c4266966401de7c4ae345cc810ee",
+                "sha256:affbb739fde390710190e3540acc9f3e65df25bd192cc0aa554f368288ee0ea2",
+                "sha256:b412f43c99ca72769306293ba83811b241d41b62ca8f358e47e0fdaf7b6fbbd7",
+                "sha256:b581ddb8df619402c377c81f186ad7f5e2726ad9f8d57047144b352f83f37522",
+                "sha256:bf7de9e847d2d14a0efcd48b290ee181fdbffb2ae54dfa2ec2a935a093730bac",
+                "sha256:c5030be8a60fb18de1fc8d93d130d57e4296c02f229200df814f6578da00429e",
+                "sha256:c89510381cbf8c8317e14e747a8b53988ad226f0ed240824064a9297b65f921d",
+                "sha256:d386630af995fd4de225d550b6806507ca09f5a650f227fddb29299335cda55e",
+                "sha256:d51ddfb3d481a6a3439db09d4b08447fb9f6b60d862ab301238f37bea8f60a6d",
+                "sha256:dd47fac2878f6102efa211461eb6fa0a6dd7b4899cd1ade6cdcb9fa9748363eb",
+                "sha256:eff55d318a114742ed2a06972f5daacfe3d5ad0c0c0d9146bcaf10acb427e6be",
+                "sha256:f2673c51e8535401c68806d331faba614bcff3ee16373481158a2e74f510b7f6",
+                "sha256:fa78bd55ec652d4a88ba254c8dae623c9992e2ce647bd17ba1a37ca2b7b42222",
+                "sha256:ffec0b854d2ed6ee98776c7168c778cdd18503642a68d36c00ba0f96d4ccff7c"
+            ],
+            "version": "==1.33.2"
+        },
+        "httplib2": {
+            "hashes": [
+                "sha256:8af66c1c52c7ffe1aa5dc4bcd7c769885254b0756e6e69f953c7f0ab49a70ba3",
+                "sha256:ca2914b015b6247791c4866782fa6042f495b94401a0f0bd3e1d6e0ba2236782"
+            ],
+            "version": "==0.18.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "version": "==2.10"
+        },
+        "msgpack": {
+            "hashes": [
+                "sha256:002a0d813e1f7b60da599bdf969e632074f9eec1b96cbed8fb0973a63160a408",
+                "sha256:25b3bc3190f3d9d965b818123b7752c5dfb953f0d774b454fd206c18fe384fb8",
+                "sha256:271b489499a43af001a2e42f42d876bb98ccaa7e20512ff37ca78c8e12e68f84",
+                "sha256:39c54fdebf5fa4dda733369012c59e7d085ebdfe35b6cf648f09d16708f1be5d",
+                "sha256:4233b7f86c1208190c78a525cd3828ca1623359ef48f78a6fea4b91bb995775a",
+                "sha256:5bea44181fc8e18eed1d0cd76e355073f00ce232ff9653a0ae88cb7d9e643322",
+                "sha256:5dba6d074fac9b24f29aaf1d2d032306c27f04187651511257e7831733293ec2",
+                "sha256:7a22c965588baeb07242cb561b63f309db27a07382825fc98aecaf0827c1538e",
+                "sha256:908944e3f038bca67fcfedb7845c4a257c7749bf9818632586b53bcf06ba4b97",
+                "sha256:9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0",
+                "sha256:aa5c057eab4f40ec47ea6f5a9825846be2ff6bf34102c560bad5cad5a677c5be",
+                "sha256:b3758dfd3423e358bbb18a7cccd1c74228dffa7a697e5be6cb9535de625c0dbf",
+                "sha256:c901e8058dd6653307906c5f157f26ed09eb94a850dddd989621098d347926ab",
+                "sha256:cec8bf10981ed70998d98431cd814db0ecf3384e6b113366e7f36af71a0fca08",
+                "sha256:db685187a415f51d6b937257474ca72199f393dad89534ebbdd7d7a3b000080e",
+                "sha256:e35b051077fc2f3ce12e7c6a34cf309680c63a842db3a0616ea6ed25ad20d272",
+                "sha256:e7bbdd8e2b277b77782f3ce34734b0dfde6cbe94ddb74de8d733d603c7f9e2b1",
+                "sha256:ea41c9219c597f1d2bf6b374d951d310d58684b5de9dc4bd2976db9e1e22c140"
+            ],
+            "version": "==1.0.0"
+        },
+        "proto-plus": {
+            "hashes": [
+                "sha256:416a0f13987789333cd8760a0ee998f8eccd6d7165ee9f283d64ca2de3e8774d"
+            ],
+            "version": "==1.11.0"
+        },
+        "protobuf": {
+            "hashes": [
+                "sha256:0e247612fadda953047f53301a7b0407cb0c3cb4ae25a6fde661597a04039b3c",
+                "sha256:0fc96785262042e4863b3f3b5c429d4636f10d90061e1840fce1baaf59b1a836",
+                "sha256:1c51fda1bbc9634246e7be6016d860be01747354ed7015ebe38acf4452f470d2",
+                "sha256:1d63eb389347293d8915fb47bee0951c7b5dab522a4a60118b9a18f33e21f8ce",
+                "sha256:22bcd2e284b3b1d969c12e84dc9b9a71701ec82d8ce975fdda19712e1cfd4e00",
+                "sha256:2a7e2fe101a7ace75e9327b9c946d247749e564a267b0515cf41dfe450b69bac",
+                "sha256:43b554b9e73a07ba84ed6cf25db0ff88b1e06be610b37656e292e3cbb5437472",
+                "sha256:4b74301b30513b1a7494d3055d95c714b560fbb630d8fb9956b6f27992c9f980",
+                "sha256:4e75105c9dfe13719b7293f75bd53033108f4ba03d44e71db0ec2a0e8401eafd",
+                "sha256:5b7a637212cc9b2bcf85dd828b1178d19efdf74dbfe1ddf8cd1b8e01fdaaa7f5",
+                "sha256:5e9806a43232a1fa0c9cf5da8dc06f6910d53e4390be1fa06f06454d888a9142",
+                "sha256:629b03fd3caae7f815b0c66b41273f6b1900a579e2ccb41ef4493a4f5fb84f3a",
+                "sha256:72230ed56f026dd664c21d73c5db73ebba50d924d7ba6b7c0d81a121e390406e",
+                "sha256:86a75477addde4918e9a1904e5c6af8d7b691f2a3f65587d73b16100fbe4c3b2",
+                "sha256:8971c421dbd7aad930c9bd2694122f332350b6ccb5202a8b7b06f3f1a5c41ed5",
+                "sha256:9616f0b65a30851e62f1713336c931fcd32c057202b7ff2cfbfca0fc7d5e3043",
+                "sha256:b0d5d35faeb07e22a1ddf8dce620860c8fe145426c02d1a0ae2688c6e8ede36d",
+                "sha256:ecc33531a213eee22ad60e0e2aaea6c8ba0021f0cce35dbf0ab03dee6e2a23a1"
+            ],
+            "version": "==3.14.0"
         },
         "psycopg2": {
             "hashes": [
@@ -59,6 +341,49 @@
             "index": "pypi",
             "version": "==2.8.6"
         },
+        "pyasn1": {
+            "hashes": [
+                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
+                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
+                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
+                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
+                "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
+                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
+                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
+                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
+                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
+                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
+                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
+                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
+            ],
+            "version": "==0.4.8"
+        },
+        "pyasn1-modules": {
+            "hashes": [
+                "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8",
+                "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199",
+                "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811",
+                "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed",
+                "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4",
+                "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e",
+                "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74",
+                "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb",
+                "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45",
+                "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd",
+                "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0",
+                "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d",
+                "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"
+            ],
+            "version": "==0.2.8"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
+                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
+            ],
+            "version": "==2.20"
+        },
         "pytz": {
             "hashes": [
                 "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268",
@@ -66,12 +391,48 @@
             ],
             "version": "==2020.4"
         },
+        "requests": {
+            "hashes": [
+                "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8",
+                "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"
+            ],
+            "version": "==2.25.0"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa",
+                "sha256:6166864e23d6b5195a5cfed6cd9fed0fe774e226d8f854fcb23b7bbef0350233"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==4.6"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "version": "==1.15.0"
+        },
         "sqlparse": {
             "hashes": [
                 "sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0",
                 "sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8"
             ],
             "version": "==0.4.1"
+        },
+        "uritemplate": {
+            "hashes": [
+                "sha256:07620c3f3f8eed1f12600845892b0e036a2420acf513c53f7de0abd911a5894f",
+                "sha256:5af8ad10cec94f215e3f48112de2022e1d5a37ed427fbd88652fa908f2ab7cae"
+            ],
+            "version": "==3.0.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
+                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+            ],
+            "version": "==1.26.2"
         },
         "uwsgi": {
             "hashes": [
@@ -84,10 +445,10 @@
     "develop": {
         "asgiref": {
             "hashes": [
-                "sha256:a5098bc870b80e7b872bff60bb363c7f2c2c89078759f6c47b53ff8c525a152e",
-                "sha256:cd88907ecaec59d78e4ac00ea665b03e571cb37e3a0e37b3702af1a9e86c365a"
+                "sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17",
+                "sha256:7162a3cb30ab0609f1a4c95938fd73e8604f63bdba516a7f7d64b83ff09478f0"
             ],
-            "version": "==3.3.0"
+            "version": "==3.3.1"
         },
         "attrs": {
             "hashes": [
@@ -297,11 +658,11 @@
         },
         "pytest-mypy": {
             "hashes": [
-                "sha256:5a667d9a2b66bf98b3a494411f221923a6e2c3eafbe771104951aaec8985673d",
-                "sha256:e0505ace48d2b19fe686366fce6b4a2ac0d090423736bb6aa2e39554d18974b7"
+                "sha256:63d418a4fea7d598ac40b659723c00804d16a251d90a5cfbca213eeba5aaf01c",
+                "sha256:8d2112972c1debf087943f48963a0daf04f3424840aea0cf437cc97053b1b0ef"
             ],
             "index": "pypi",
-            "version": "==0.7.0"
+            "version": "==0.8.0"
         },
         "pytest-yapf": {
             "hashes": [

--- a/server/api_project/api/tests/views/test_board_api_views.py
+++ b/server/api_project/api/tests/views/test_board_api_views.py
@@ -1,12 +1,23 @@
 import json
 from uuid import uuid4
 
+import pytest
 from django.test import Client, TestCase
 from django.urls import reverse
+from mock import Mock, patch
 from rest_framework import status
 
 from ...models import Board, CardList, User
 from ...serializers import BoardSerializer
+
+
+@pytest.fixture(scope='module', autouse=True)
+def patch_authentication():
+    with patch(
+        'firebase_auth.firebase_authentication.FirebaseAuthentication.authenticate',
+        return_value=(Mock(), None)
+    ):
+        yield
 
 
 class TestGetBoard(TestCase):

--- a/server/api_project/api/tests/views/test_card_api_views.py
+++ b/server/api_project/api/tests/views/test_card_api_views.py
@@ -1,12 +1,23 @@
 import json
 from uuid import uuid4
 
+import pytest
 from django.test import Client, TestCase
 from django.urls import reverse
+from mock import Mock, patch
 from rest_framework import status
 
 from ...models import Board, Card, CardList, User
 from ...serializers import CardSerializer
+
+
+@pytest.fixture(scope='module', autouse=True)
+def patch_authentication():
+    with patch(
+        'firebase_auth.firebase_authentication.FirebaseAuthentication.authenticate',
+        return_value=(Mock(), None)
+    ):
+        yield
 
 
 class TestGetCard(TestCase):

--- a/server/api_project/api/tests/views/test_card_list_api_views.py
+++ b/server/api_project/api/tests/views/test_card_list_api_views.py
@@ -1,12 +1,23 @@
 import json
 from uuid import uuid4
 
+import pytest
 from django.test import Client, TestCase
 from django.urls import reverse
+from mock import Mock, patch
 from rest_framework import status
 
 from ...models import Board, Card, CardList, User
 from ...serializers import CardListSerializer
+
+
+@pytest.fixture(scope='module', autouse=True)
+def patch_authentication():
+    with patch(
+        'firebase_auth.firebase_authentication.FirebaseAuthentication.authenticate',
+        return_value=(Mock(), None)
+    ):
+        yield
 
 
 class TestGetCardList(TestCase):

--- a/server/api_project/api/tests/views/test_users_api_views.py
+++ b/server/api_project/api/tests/views/test_users_api_views.py
@@ -1,12 +1,23 @@
 import json
 from uuid import uuid4
 
+import pytest
 from django.test import Client, TestCase
 from django.urls import reverse
+from mock import Mock, patch
 from rest_framework import status
 
 from ...models import Board, User
 from ...serializers import UserSerializer
+
+
+@pytest.fixture(scope='module', autouse=True)
+def patch_authentication():
+    with patch(
+        'firebase_auth.firebase_authentication.FirebaseAuthentication.authenticate',
+        return_value=(Mock(), None)
+    ):
+        yield
 
 
 class TestGetUser(TestCase):
@@ -22,91 +33,15 @@ class TestGetUser(TestCase):
         )
 
         self.client = Client()
-        self.get_delete_update_endpoint = reverse(
-            'get_delete_update_user', kwargs={'pk': self.user.pk}
+        self.get_user_endpoint = reverse(
+            'get_user', kwargs={'pk': self.user.pk}
         )
 
     def test_get_user(self):
-        r = self.client.get(self.get_delete_update_endpoint)
+        r = self.client.get(self.get_user_endpoint)
 
         expected = UserSerializer(self.user)
 
         self.assertEqual(r.status_code, status.HTTP_200_OK)
         self.assertEqual(r.data, expected.data)
         self.assertEqual(len(r.data.get('boards')), 2)
-
-
-class TestDeleteUser(TestCase):
-    def setUp(self):
-        self.user_uid = str(uuid4())
-        self.user = User.objects.create_user(firebase_uid=self.user_uid)
-
-        self.client = Client()
-        self.get_delete_update_endpoint = reverse(
-            'get_delete_update_user', kwargs={'pk': self.user.pk}
-        )
-
-    def test_delete_user(self):
-        r = self.client.delete(self.get_delete_update_endpoint)
-
-        self.assertEqual(r.status_code, status.HTTP_204_NO_CONTENT)
-
-
-class TestPutUser(TestCase):
-    def setUp(self):
-        self.user_uid = str(uuid4())
-        self.user = User.objects.create_user(firebase_uid=self.user_uid)
-
-        self.client = Client()
-        self.get_delete_update_endpoint = reverse(
-            'get_delete_update_user', kwargs={'pk': self.user.pk}
-        )
-
-        self.valid_data = {'firebase_uid': 'foo'}
-
-        self.invalid_data = {'this_is_invalid': 'bar'}
-
-    def test_update_user(self):
-        r = self.client.put(
-            self.get_delete_update_endpoint,
-            kwargs={'pk': self.user.pk},
-            data=json.dumps(self.valid_data),
-            content_type='application/json'
-        )
-
-        updated_firebase_uid = User.objects.get(pk=self.user.pk).firebase_uid
-
-        self.assertEqual(r.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(
-            updated_firebase_uid, self.valid_data.get('firebase_uid')
-        )
-
-    def test_invalid_user_update(self):
-        r = self.client.put(
-            self.get_delete_update_endpoint,
-            kwargs={'pk': self.user.pk},
-            data=json.dumps(self.invalid_data),
-            content_type='application/json'
-        )
-
-        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
-
-
-class TestCreateUser(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.create_user_endpoint = reverse('create_user')
-        self.user_uid = str(uuid4())
-
-    def test_create_user(self):
-        r = self.client.post(
-            self.create_user_endpoint,
-            data=json.dumps({'firebase_uid': self.user_uid}),
-            content_type='application/json'
-        )
-
-        user = User.objects.get(firebase_uid=self.user_uid)
-
-        self.assertEqual(r.status_code, status.HTTP_201_CREATED)
-        self.assertTrue(isinstance(user, User))
-        self.assertEqual(user.firebase_uid, self.user_uid)

--- a/server/api_project/api/urls.py
+++ b/server/api_project/api/urls.py
@@ -3,12 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path(
-        'api/v1/user/<int:pk>',
-        views.get_delete_update_user,
-        name='get_delete_update_user'
-    ),
-    path('api/v1/users/', views.create_user, name='create_user'),
+    path('api/v1/user/<int:pk>', views.get_user, name='get_user'),
     path(
         'api/v1/board/<int:pk>',
         views.get_delete_update_board,

--- a/server/api_project/api/views.py
+++ b/server/api_project/api/views.py
@@ -41,14 +41,9 @@ def _handle_post(request, serializer):
 
 
 # USER VIEWS
-@api_view(['GET', 'DELETE', 'PUT'])
-def get_delete_update_user(request, pk):
+@api_view(['GET'])
+def get_user(request, pk):
     return _handle_get_delete_update(request, pk, UserSerializer, User)
-
-
-@api_view(['POST'])
-def create_user(request):
-    return _handle_post(request, UserSerializer)
 
 
 # BOARD VIEWS

--- a/server/api_project/api_project/settings.py
+++ b/server/api_project/api_project/settings.py
@@ -32,8 +32,8 @@ ALLOWED_HOSTS = ['0.0.0.0']
 INSTALLED_APPS = [
     'django.contrib.admin', 'django.contrib.auth',
     'django.contrib.contenttypes', 'django.contrib.sessions',
-    'django.contrib.messages', 'django.contrib.staticfiles', 'api',
-    'firebase_auth'
+    'django.contrib.messages', 'django.contrib.staticfiles', 'rest_framework',
+    'api', 'firebase_auth'
 ]
 
 MIDDLEWARE = [
@@ -124,7 +124,12 @@ REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [],
-    'TEST_REQUEST_DEFAULT_FORMAT': 'json'
+    'TEST_REQUEST_DEFAULT_FORMAT':
+    'json',
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+        'firebase_auth.firebase_authentication.FirebaseAuthentication',
+    ),
 }
 
 AUTH_USER_MODEL = 'api.User'

--- a/server/api_project/api_project/settings.py
+++ b/server/api_project/api_project/settings.py
@@ -32,7 +32,8 @@ ALLOWED_HOSTS = ['0.0.0.0']
 INSTALLED_APPS = [
     'django.contrib.admin', 'django.contrib.auth',
     'django.contrib.contenttypes', 'django.contrib.sessions',
-    'django.contrib.messages', 'django.contrib.staticfiles', 'api'
+    'django.contrib.messages', 'django.contrib.staticfiles', 'api',
+    'firebase_auth'
 ]
 
 MIDDLEWARE = [

--- a/server/api_project/api_project/test_settings.py
+++ b/server/api_project/api_project/test_settings.py
@@ -6,11 +6,3 @@ DATABASES = {
         'NAME': ':memory:'
     }
 }
-
-# REST_FRAMEWORK = {
-#     # Use Django's standard `django.contrib.auth` permissions,
-#     # or allow read-only access for unauthenticated users.
-#     'DEFAULT_PERMISSION_CLASSES': [],
-#     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
-#     'DEFAULT_AUTHENTICATION_CLASSES': (),
-# }

--- a/server/api_project/api_project/test_settings.py
+++ b/server/api_project/api_project/test_settings.py
@@ -6,3 +6,12 @@ DATABASES = {
         'NAME': ':memory:'
     }
 }
+
+REST_FRAMEWORK = {
+    # Use Django's standard `django.contrib.auth` permissions,
+    # or allow read-only access for unauthenticated users.
+    'DEFAULT_PERMISSION_CLASSES': [],
+    'TEST_REQUEST_DEFAULT_FORMAT':
+    'json',
+    'DEFAULT_AUTHENTICATION_CLASSES': (),
+}

--- a/server/api_project/api_project/test_settings.py
+++ b/server/api_project/api_project/test_settings.py
@@ -7,11 +7,10 @@ DATABASES = {
     }
 }
 
-REST_FRAMEWORK = {
-    # Use Django's standard `django.contrib.auth` permissions,
-    # or allow read-only access for unauthenticated users.
-    'DEFAULT_PERMISSION_CLASSES': [],
-    'TEST_REQUEST_DEFAULT_FORMAT':
-    'json',
-    'DEFAULT_AUTHENTICATION_CLASSES': (),
-}
+# REST_FRAMEWORK = {
+#     # Use Django's standard `django.contrib.auth` permissions,
+#     # or allow read-only access for unauthenticated users.
+#     'DEFAULT_PERMISSION_CLASSES': [],
+#     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+#     'DEFAULT_AUTHENTICATION_CLASSES': (),
+# }

--- a/server/api_project/api_project/urls.py
+++ b/server/api_project/api_project/urls.py
@@ -19,5 +19,6 @@ from django.urls import path
 
 urlpatterns = [
     path('', include('api.urls')),
+    path('', include('firebase_auth.urls')),
     path('admin/', admin.site.urls),
 ]

--- a/server/api_project/firebase_auth/admin.py
+++ b/server/api_project/firebase_auth/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/server/api_project/firebase_auth/admin.py
+++ b/server/api_project/firebase_auth/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/server/api_project/firebase_auth/apps.py
+++ b/server/api_project/firebase_auth/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class FirebaseAuthConfig(AppConfig):
+    name = 'firebase_auth'

--- a/server/api_project/firebase_auth/custom_exceptions.py
+++ b/server/api_project/firebase_auth/custom_exceptions.py
@@ -1,0 +1,14 @@
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class NoAuthenticationToken(APIException):
+    status_code = status.HTTP_401_UNAUTHORIZED
+    default_detail = 'No auth token provided'
+    default_code = 'no_auth_token'
+
+
+class Unauthorized(APIException):
+    status_code = status.HTTP_401_UNAUTHORIZED
+    default_detail = 'Token not valid'
+    default_code = 'token_not_valid'

--- a/server/api_project/firebase_auth/firebase.py
+++ b/server/api_project/firebase_auth/firebase.py
@@ -1,0 +1,20 @@
+import os
+import firebase_admin
+from firebase_admin import credentials
+
+creds = {
+    'type': os.getenv('FIREBASE_TYPE'),
+    'project_id': os.getenv('FIREBASE_PROJECT_ID'),
+    'private_key_id': os.getenv('FIREBASE_PRIVATE_KEY_ID'),
+    'private_key': os.getenv('FIREBASE_PRIVATE_KEY').replace('\\n', '\n'),
+    'client_email': os.getenv('FIREBASE_CLIENT_EMAIL'),
+    'client_id': os.getenv('FIREBASE_CLIENT_ID'),
+    'auth_uri': os.getenv('FIREBASE_AUTH_URI'),
+    'token_uri': os.getenv('FIREBASE_TOKEN_URI'),
+    'auth_provider_x509_cert_url': os.getenv('FIREBASE_AUTH_PROVIDER_CERT_URL'),
+    'client_x509_cert_url': os.getenv('FIREBASE_CLIENT_CERT_URL')
+}
+
+creds_obj = credentials.Certifacte(creds)
+
+firebase = firebase_admin.initialize_app(creds_obj)

--- a/server/api_project/firebase_auth/firebase.py
+++ b/server/api_project/firebase_auth/firebase.py
@@ -1,4 +1,5 @@
 import os
+
 import firebase_admin
 from firebase_admin import credentials
 
@@ -11,10 +12,11 @@ creds = {
     'client_id': os.getenv('FIREBASE_CLIENT_ID'),
     'auth_uri': os.getenv('FIREBASE_AUTH_URI'),
     'token_uri': os.getenv('FIREBASE_TOKEN_URI'),
-    'auth_provider_x509_cert_url': os.getenv('FIREBASE_AUTH_PROVIDER_CERT_URL'),
+    'auth_provider_x509_cert_url':
+    os.getenv('FIREBASE_AUTH_PROVIDER_CERT_URL'),
     'client_x509_cert_url': os.getenv('FIREBASE_CLIENT_CERT_URL')
 }
 
-creds_obj = credentials.Certifacte(creds)
+creds_obj = credentials.Certificate(creds)
 
 firebase = firebase_admin.initialize_app(creds_obj)

--- a/server/api_project/firebase_auth/firebase_authentication.py
+++ b/server/api_project/firebase_auth/firebase_authentication.py
@@ -1,5 +1,29 @@
-import .firebase_authentication import firebase
+from firebase_admin import auth
+
+from api.models import User
+
+from .custom_exceptions import NoAuthenticationToken, Unauthorized
+from .firebase import firebase
 
 
 class FirebaseAuthentication():
-    pass
+    def authenticate(self, request):
+        authorization_header = request.META.get('HTTP_AUTHORIZATION')
+
+        if not authorization_header:
+            raise NoAuthenticationToken()
+
+        id_token = authorization_header.split(' ').pop()
+        try:
+            # Verify the ID token and check if the token has been revoked by
+            # passing check_revoked=True.
+            decoded = auth.verify_id_token(id_token, check_revoked=True)
+        except Exception:
+            raise Unauthorized('Token is not valid')
+
+        if not decoded.get('uid'):
+            return None
+
+        user, _ = User.objects.get_or_create(firebase_uid=decoded.get('uid'))
+
+        return user or None

--- a/server/api_project/firebase_auth/firebase_authentication.py
+++ b/server/api_project/firebase_auth/firebase_authentication.py
@@ -18,12 +18,10 @@ class FirebaseAuthentication():
             # Verify the ID token and check if the token has been revoked by
             # passing check_revoked=True.
             decoded = auth.verify_id_token(id_token, check_revoked=True)
+            firebase_uid = decoded['uid']
         except Exception:
             raise Unauthorized('Token is not valid')
 
-        if not decoded.get('uid'):
-            return None
+        user, _ = User.objects.get_or_create(firebase_uid=firebase_uid)
 
-        user, _ = User.objects.get_or_create(firebase_uid=decoded.get('uid'))
-
-        return user or None
+        return (user, None)

--- a/server/api_project/firebase_auth/firebase_authentication.py
+++ b/server/api_project/firebase_auth/firebase_authentication.py
@@ -1,0 +1,5 @@
+import .firebase_authentication import firebase
+
+
+class FirebaseAuthentication():
+    pass

--- a/server/api_project/firebase_auth/models.py
+++ b/server/api_project/firebase_auth/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/server/api_project/firebase_auth/models.py
+++ b/server/api_project/firebase_auth/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/server/api_project/firebase_auth/tests.py
+++ b/server/api_project/firebase_auth/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/server/api_project/firebase_auth/tests.py
+++ b/server/api_project/firebase_auth/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/server/api_project/firebase_auth/tests/test_firebase_authentication.py
+++ b/server/api_project/firebase_auth/tests/test_firebase_authentication.py
@@ -1,9 +1,12 @@
+from uuid import uuid4
+
 from django.test import TestCase
 from mock import Mock, patch
-from uuid import uuid4
+
+from api.models import User
+
 from ..custom_exceptions import NoAuthenticationToken, Unauthorized
 from ..firebase_authentication import FirebaseAuthentication
-from api.models import User
 
 
 def _mock_firebase_admin_auth(decoded):
@@ -32,10 +35,11 @@ class TestFirebaseAuthentication(TestCase):
         'firebase_auth.firebase_authentication.auth',
         _mock_firebase_admin_auth({})
     )
-    def test_authenticate_returns_none_when_no_uid_in_decode(self):
+    def test_authenticate_raises_unauthorized_when_no_uid_in_decode(self):
         request = Mock()
 
-        self.assertEqual(FirebaseAuthentication().authenticate(request), None)
+        with self.assertRaises(Unauthorized):
+            FirebaseAuthentication().authenticate(request)
 
     @patch(
         'firebase_auth.firebase_authentication.auth',
@@ -44,6 +48,6 @@ class TestFirebaseAuthentication(TestCase):
     def test_authenticate_returns_user(self):
         request = Mock()
 
-        user = FirebaseAuthentication().authenticate(request)
+        authenticated = FirebaseAuthentication().authenticate(request)
 
-        self.assertTrue(isinstance(user, User))
+        self.assertTrue(isinstance(authenticated[0], User))

--- a/server/api_project/firebase_auth/tests/test_firebase_authentication.py
+++ b/server/api_project/firebase_auth/tests/test_firebase_authentication.py
@@ -1,0 +1,49 @@
+from django.test import TestCase
+from mock import Mock, patch
+from uuid import uuid4
+from ..custom_exceptions import NoAuthenticationToken, Unauthorized
+from ..firebase_authentication import FirebaseAuthentication
+from api.models import User
+
+
+def _mock_firebase_admin_auth(decoded):
+    auth = Mock()
+    auth.verify_id_token = Mock(return_value=decoded)
+
+    return auth
+
+
+class TestFirebaseAuthentication(TestCase):
+    def test_authenticate_without_auth_header(self):
+        request = Mock()
+        request.META = {}
+
+        with self.assertRaises(NoAuthenticationToken):
+            FirebaseAuthentication().authenticate(request)
+
+    def test_authenticate_raises_unauthorized_when_token_invalid(self):
+        request = Mock()
+        request.META = {'HTTP_AUTHORIZATION': 'Bearer invalid-token'}
+
+        with self.assertRaises(Unauthorized):
+            FirebaseAuthentication().authenticate(request)
+
+    @patch(
+        'firebase_auth.firebase_authentication.auth',
+        _mock_firebase_admin_auth({})
+    )
+    def test_authenticate_returns_none_when_no_uid_in_decode(self):
+        request = Mock()
+
+        self.assertEqual(FirebaseAuthentication().authenticate(request), None)
+
+    @patch(
+        'firebase_auth.firebase_authentication.auth',
+        _mock_firebase_admin_auth({'uid': str(uuid4())})
+    )
+    def test_authenticate_returns_user(self):
+        request = Mock()
+
+        user = FirebaseAuthentication().authenticate(request)
+
+        self.assertTrue(isinstance(user, User))

--- a/server/api_project/firebase_auth/tests/views/test_authenticate.py
+++ b/server/api_project/firebase_auth/tests/views/test_authenticate.py
@@ -1,0 +1,28 @@
+from uuid import uuid4
+
+from django.test import Client, TestCase
+from django.urls import reverse
+from mock import Mock, patch
+from rest_framework import status
+
+from api.models import Board, User
+from api.serializers import UserSerializer
+
+
+class TestAuthenticate(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.auth_endpoint = reverse('authenticate')
+        self.user = User.objects.create(firebase_uid=str(uuid4()))
+
+    def test_authenticated_user(self):
+        with patch(
+            'firebase_auth.firebase_authentication.FirebaseAuthentication.authenticate',
+            Mock(return_value=(self.user, None))
+        ):
+            r = self.client.get(self.auth_endpoint)
+
+            expected = UserSerializer(self.user)
+
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            self.assertEqual(r.data, expected.data)

--- a/server/api_project/firebase_auth/urls.py
+++ b/server/api_project/firebase_auth/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path('api/v1/authenticate/', views.authenticate, name='authenticate'),
+]

--- a/server/api_project/firebase_auth/views.py
+++ b/server/api_project/firebase_auth/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/server/api_project/firebase_auth/views.py
+++ b/server/api_project/firebase_auth/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/server/api_project/firebase_auth/views.py
+++ b/server/api_project/firebase_auth/views.py
@@ -1,0 +1,17 @@
+from rest_framework import status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from api.serializers import UserSerializer
+
+
+@api_view(['GET'])
+def authenticate(request):
+    """
+        Authenticates user and responds with serialized
+        authenticated user entity.
+    """
+    serialized = UserSerializer(request.user)
+    response_data = serialized.data
+
+    return Response(response_data, status=status.HTTP_200_OK)

--- a/server/api_project/setup.cfg
+++ b/server/api_project/setup.cfg
@@ -46,3 +46,4 @@ omit =
     *settings*,
     *urls.py,
     *wsgi.py,
+    *asgi.py,

--- a/server/api_project/setup.cfg
+++ b/server/api_project/setup.cfg
@@ -46,4 +46,3 @@ omit =
     *settings*,
     *urls.py,
     *wsgi.py,
-    *asgi.py,


### PR DESCRIPTION
#### What ?

I want to be able to create anonymous users so users can create cards and store them. 
I've opted to use a 3rd party authentication provider for this use case, Firebase Auth. So long as a user does not clear their cookies they will be able to retrieve cards previously created.

#### How?
- Created an authenticate endpoint and authentication backend to validate the Firebase JWT from the client
- It authenticates, creates and returns a user, which Django attaches to the request object.
- Removed PUT, DELETE and POST user endpoints and tests. User creation now happens on authentication. I do not require DELETE functionality at the moment.

